### PR TITLE
checkBundleStatus getting confused if a server is "missing"

### DIFF
--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
@@ -284,10 +284,10 @@ class CqPackageHelper {
         def slingServersConfiguration = slingServersConfiguration()
 
         slingServersConfiguration.each { slingServerConfiguration ->
-            slingServerConfiguration.slingSupport.doHttp { httpClient ->
-                slingBundle.checkActiveBundles(groupProperty, httpClient, slingServerConfiguration.slingSupport,
-                    slingServerConfiguration.name, slingServerConfiguration.bundleControlUriJson
-                )
+            def slingSupport = slingServerConfiguration.slingSupport
+
+            slingSupport.doHttp { httpClient ->
+                slingBundle.checkActiveBundles(groupProperty, httpClient, slingServerConfiguration)
             }
         }
     }

--- a/src/test/groovy/com/twcable/gradle/sling/SlingServerFixture.groovy
+++ b/src/test/groovy/com/twcable/gradle/sling/SlingServerFixture.groovy
@@ -16,6 +16,7 @@
 
 package com.twcable.gradle.sling
 
+import com.twcable.gradle.sling.osgi.BundleState
 import groovy.json.JsonBuilder
 
 class SlingServerFixture extends FixtureBase {
@@ -67,15 +68,20 @@ class SlingServerFixture extends FixtureBase {
             ]
         }
 
+        def actCount = bundles.count { SlingBundleFixture bundle -> bundle.bundleState.stateString == BundleState.ACTIVE.stateString }
+        def fraCount = bundles.count { SlingBundleFixture bundle -> bundle.bundleState.stateString == BundleState.FRAGMENT.stateString }
+        def resCount = bundles.count { SlingBundleFixture bundle -> bundle.bundleState.stateString == BundleState.RESOLVED.stateString }
+        def insCount = bundles.count { SlingBundleFixture bundle -> bundle.bundleState.stateString == BundleState.INSTALLED.stateString }
+
         [data  : data,
          s     : [
-             279,
-             272,
-             7,
-             0,
-             0
+             bundles.size(),
+             actCount,
+             fraCount,
+             resCount,
+             insCount
          ],
-         status: "Bundle information: 279 bundles in total - all 279 bundles active."
+         status: "Bundle information: ${bundles.size()} bundles in total - all 279 bundles active."
         ]
     }
 


### PR DESCRIPTION
For example, if your configuration says to check author and publisher but publisher is not currently running, `checkBundleStatus` will keep waiting for all the bundles to be active on publisher (which of course won't happen) and then fail.
