### PR TITLE
Added commons-io dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     testCompile "org.codehaus.groovy:groovy-all:2.3.6"
     testCompile "org.gradle:gradle-core:2.2"
 
+    compile "commons-io:commons-io:1.4"
+
     compile "org.apache.httpcomponents:httpclient:${httpcomponents_version}"
     compile "org.apache.httpcomponents:httpmime:${httpcomponents_version}"
 


### PR DESCRIPTION
Hey @jdigger , looks like we left out adding commons-io to our dependencies.  The gradle api seems to add this as a transitive dependency, so we weren't seeing any compilation, or test runtime issues.  When pulled down from bintray however, we were seeing ClassNotFoundExceptions for IOUtils when running cqpackage
