### PR TITLE
Exclude group com.adobe.aem for AEM 6.0

### DIFF
--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageConfiguration.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageConfiguration.groovy
@@ -50,6 +50,7 @@ class CqPackageConfiguration {
         packageExclusions = [
             exclude([group: 'com.day.cq']),
             exclude([group: 'com.day.cq.wcm']),
+            exclude([group: 'com.adobe.aem']),
             exclude([group: 'commons-codec']),
             exclude([group: 'commons-io']),
             exclude([group: 'commons-lang3']),

--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackagePlugin.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackagePlugin.groovy
@@ -452,6 +452,7 @@ class CqPackagePlugin implements Plugin<Project> {
             packageDeps.with { // TODO: should come from configuration
                 exclude group: 'com.day.cq'
                 exclude group: 'com.day.cq.wcm'
+                exclude group: 'com.adobe.aem'
                 exclude group: 'commons-codec'
                 exclude group: 'commons-io'
                 exclude group: 'commons-lang3'


### PR DESCRIPTION
Couldn't find a relevant test to update.  I am assuming that if there were a reasonable way to create a test that you would already have done so.  This adds com.adobe.aem to exclude the 6.0 uber jar from the package.
