### PR TITLE
Fixed installPackage task

### DIFF
--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
@@ -126,7 +126,7 @@ class CqPackageHelper {
 
 
     void installPackage() {
-        def command = new CqPackageCommand('install', this, {
+        def command = new CqPackageCommand('install', this, { SlingServerConfiguration serverConfig, String jsonMsg ->
             return false
         }, false)
 


### PR DESCRIPTION
@jdigger Can you please review and approve the changes as `installPackage` task is failing with the below message?

```
No signature of method: com.twcable.gradle.cqpackage.CqPackageHelper$_installPackage_closure2.call() is applicable for argument types: (com.twcable.gradle.sling.SlingServerConfiguration, java.lang.String) values: [com.twcable.gradle.sling.SlingServerConfiguration@10afc66a, ...]
```
