### PR TITLE
Gets rid of NPE when uninstalling

### DIFF
--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
@@ -397,7 +397,12 @@ class CqPackageHelper {
                 }
 
                 def bundleSymbolicName = getSymbolicName(jarFile)
-                symbolicNames.add(bundleSymbolicName)
+                if (bundleSymbolicName != null) {
+                    symbolicNames.add(bundleSymbolicName)
+                }
+                else {
+                    logger.warn "${file} contains a non-OSGi jar file: ${jarFile}"
+                }
                 logger.debug("Cleaning up. Deleting $jarFile...")
                 jarFile.delete()
             }

--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackagePlugin.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackagePlugin.groovy
@@ -336,7 +336,7 @@ class CqPackagePlugin implements Plugin<Project> {
             // name match this project's group name
             if (serversConfiguration.uninstallBundlesPredicate == null) {
                 serversConfiguration.uninstallBundlesPredicate = { String symbolicName ->
-                    symbolicName.contains(project.group as CharSequence)
+                    symbolicName?.contains(project.group as CharSequence)
                 }
             }
 


### PR DESCRIPTION
If the package contains a non-OSGi jar file, the uninstaller would get an NPE.

Fixed both at the point where the NPE would happen, as well preventing the collection of symbolic names from having nulls in it in the first place. Also added logging that will warn the user that the package contains non-OSGi jars, which shouldn't happen.

Fixed GH-9
