### PR TITLE
Made createPackage.contentSrc more flexible

### DIFF
--- a/docs/CqPackagePlugin.adoc
+++ b/docs/CqPackagePlugin.adoc
@@ -28,7 +28,7 @@ reinstall::
   Convenience task that simple depends on `clean`, `uninstall`, `remove`, `install`, then `verifyBundles`.
 
 installPackage::
-  Installs the CQ Package
+  Installs the CQ Package that has been uploaded. **Note** Uses the name of the package. See below.
 
 validateBundles::
   Checks all the JARs that are included in the package to make sure they are installed and in an

--- a/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
+++ b/src/main/groovy/com/twcable/gradle/cqpackage/CqPackageHelper.groovy
@@ -195,11 +195,16 @@ class CqPackageHelper {
     Map getPackageInfo(SlingServerConfiguration serverConfig) {
         def packagesInfo = listPackages(serverConfig)
         if (packagesInfo != null) {
-            return packagesInfo.results.find { Map packageInfo ->
+            def packageMap = packagesInfo.results.find { Map packageInfo ->
                 packageInfo.name == packageName
             } as Map
+            if (packageMap == null) {
+                logger.info "Could not find ${packageName} in ${packagesInfo.results.collect { Map pi -> pi.name }}"
+            }
+            return packageMap
         }
         else {
+            logger.warn "Did not get a list of packages on ${serverConfig.name}"
             return null
         }
     }

--- a/src/main/groovy/com/twcable/gradle/sling/SlingSupport.groovy
+++ b/src/main/groovy/com/twcable/gradle/sling/SlingSupport.groovy
@@ -204,6 +204,7 @@ class SlingSupport {
     HttpResponse doGet(URI url, SimpleHttpClient httpClient) {
         if (!serverConf.active) return new HttpResponse(HTTP_CLIENT_TIMEOUT, "${serverConf.name} is not responding")
         if (url == null) return new HttpResponse(HTTP_NOT_FOUND, 'Missing URL')
+        log.info "GET ${url}"
         HttpGet get = new HttpGet(url)
         def resp = httpClient.execute(get)
         if (resp.code == HTTP_CLIENT_TIMEOUT) serverConf.active = false


### PR DESCRIPTION
Setting `contentSrc` on `createPackage` now works more as you would expect.

Added better logging for installation.
